### PR TITLE
Compiling source code, do not execute loop idiom pass

### DIFF
--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -469,6 +469,8 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   }
 
   PMBuilder.populateFunctionPassManager(FPM);
+  if (LangOpts.SYCLIsDevice)
+  	PMBuilder.EnableLoopIdiom = false;
   PMBuilder.populateModulePassManager(MPM);
 }
 

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -469,8 +469,12 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   }
 
   PMBuilder.populateFunctionPassManager(FPM);
+  // Since llvm.memcpy intrinsics with potential mixed address spaces would
+  // choke current Xilinx xocc compiler, the EnableLoopIdiom flag here is set
+  // to false for not executing "loop idiom" pass when compiling souce code
+  // of SYCL kernel.
   if (LangOpts.SYCLIsDevice)
-  	PMBuilder.EnableLoopIdiom = false;
+    PMBuilder.EnableLoopIdiom = false;
   PMBuilder.populateModulePassManager(MPM);
 }
 


### PR DESCRIPTION
Add EnableLoopIdiom flag to separate host and device
compilation. While compiling kernel code, do not execute loop idiom
pass to avoid llvm.memcpy intrinsics to have different address pointer
source and destination.