### PR TITLE
Modify for also skipping "loop idiom" pass for host at the first place

### DIFF
--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -473,7 +473,12 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
   // choke current Xilinx xocc compiler, the EnableLoopIdiom flag here is set
   // to false for not executing "loop idiom" pass when compiling souce code
   // of SYCL kernel.
-  if (LangOpts.SYCLIsDevice)
+  // And Since argument promotion can only be done with GEP instructions that
+  // only used by loads. If llvm.memcpy intrinsics, there will always be a
+  // cast instruction before to cast the pointer, so for the host code, the
+  // EnableLoopIdiom flag here force skipping "loop idiom" pass. The pass will
+  // be executed after "SYCL arguments flattening" pass.
+  if (LangOpts.SYCL)
     PMBuilder.EnableLoopIdiom = false;
   PMBuilder.populateModulePassManager(MPM);
 }


### PR DESCRIPTION
The "loop idiom" pass will be applied to the host after "SYCL argument flattening" pass. This is done in triSYCL makefile to add -loop-idiom 